### PR TITLE
Modify register method in using-solution-providers

### DIFF
--- a/docs/solutions/using-solution-providers.md
+++ b/docs/solutions/using-solution-providers.md
@@ -66,16 +66,16 @@ use Illuminate\Support\ServiceProvider;
 class YourServiceProvider extends ServiceProvider
 {
     /**
-     * Register services.
+     * boot services.
      *
      * @return void
      */
-    public function register(SolutionProviderRepository $solutionProviderRepository)
+    public function boot()
     {
-        $solutionProviderRepository->registerSolutionProvider(GenerateAppKeySolution::class);
+        $this->app->make(SolutionProviderRepository::class)->registerSolutionProvider(GenerateAppKeySolution::class);
 
         // alternatively you can register multiple solution providers at once
-        $solutionProviderRepository->registerSolutionProviders([
+        $this->app->make(SolutionProviderRepository::class)->registerSolutionProviders([
             MySolution::class,
             AnotherSolution::class,
         ]);


### PR DESCRIPTION
this **PR** fixes registering Solution providers

using **register(SolutionProviderRepository $solutionProviderRepository)** throws **Declaration of register should be compatible with Illuminate\Support\ServiceProvider::register()**

and when putting **$this->app->make(SolutionProviderRepository::class)->registerSolutionProvider(GenerateAppKeySolution::class)** inside **register()** method it throws **Target [Facade\IgnitionContracts\SolutionProviderRepository] is not instantiable** 

so the only place was applicable is inside **boot()** method . [like ignition-stackoverflow](https://github.com/Astrotomic/ignition-stackoverflow/blob/master/src/TabServiceProvider.php#L20)