### PR TITLE
Update glow docs

### DIFF
--- a/docs/ignition-for-laravel/adding-glows.md
+++ b/docs/ignition-for-laravel/adding-glows.md
@@ -11,6 +11,7 @@ To add a glow to your application, you can use the `Facade\FlareClient\Flare` cl
 
 ```php
 use Facade\Ignition\Facades\Flare;
+use Facade\FlareClient\Enums\MessageLevels;
 
-Flare::glow('Tenant', 'My-Tenant-Identifier');
+Flare::glow('This is a message from glow!', MessageLevels::DEBUG, func_get_args());
 ```


### PR DESCRIPTION
Glows aren't used like the documentation states anymore, in fact it seems the concept of an "identifier" is gone now?

Not too sure what's going on here, but figured an example like this would be better.